### PR TITLE
devhub-tmp-cnu-codefix-uploader-go to 0.0.76

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -2,6 +2,9 @@ dependencies:
 - name: atsea-main-app-shah
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.49
+- name: devhub-tmp-cnu-codefix-uploader-go
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.76
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote devhub-tmp-cnu-codefix-uploader-go to version 0.0.76